### PR TITLE
Use phase0, altair forks to fetch types instead of presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-![ETH2_Spec_Version 0.11.2](https://img.shields.io/badge/ETH2_Spec_Version-0.11.2-2e86c1.svg)
+![ETH2_Spec_Version 1.0.0](https://img.shields.io/badge/ETH2_Spec_Version-1.0.0-2e86c1.svg)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-![ETH2_Spec_Version 1.0.0](https://img.shields.io/badge/ETH2_Spec_Version-1.0.0-2e86c1.svg)
+![ETH2_Spec_Version v1.1.0-alpha.7](https://img.shields.io/badge/ETH2_Spec_Version-v1.1.0.alpha.7-2e86c1.svg)

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@chainsafe/lodestar-config": "^0.9.0",
-    "@chainsafe/lodestar-types": "^0.9.0",
-    "@chainsafe/ssz": "^0.6.7",
+    "@chainsafe/lodestar-config": "^0.25.1",
+    "@chainsafe/lodestar-types": "^0.25.1",
+    "@chainsafe/ssz": "^0.8.11",
     "@types/bn.js": "^4.11.5",
     "@types/deep-equal": "^1.0.1",
     "@types/file-saver": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "cross-env NODE_ENV=production webpack --color --progress",
     "start": "serve dist",
     "lint": "eslint --ext .tsx src/",
-    "lint-fix": "eslint --ext .tsx src/ --fix"
+    "lint:fix": "eslint --ext .tsx src/ --fix"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@chainsafe/lodestar-config": "^0.25.1",
-    "@chainsafe/lodestar-types": "^0.25.1",
+    "@chainsafe/lodestar-config": "^0.25.0",
+    "@chainsafe/lodestar-types": "^0.25.0",
     "@chainsafe/ssz": "^0.8.11",
     "@types/bn.js": "^4.11.5",
     "@types/deep-equal": "^1.0.1",

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -17,6 +17,7 @@ type Props<T> = {
 };
 
 type State = {
+  forkName: ForkName;
   presetName: PresetName;
   sszTypeName: string;
   input: string;
@@ -51,6 +52,7 @@ class Input<T> extends React.Component<Props<T>, State> {
       .catch((error: { message: string }) => this.handleError(error));
 
     this.state = {
+      forkName: "allForks",
       presetName: DEFAULT_PRESET,
       input: "",
       sszTypeName: initialType,
@@ -147,6 +149,12 @@ class Input<T> extends React.Component<Props<T>, State> {
 
   setPreset(e: ChangeEvent<HTMLSelectElement>): void {
     this.setState({presetName: e.target.value as PresetName}, () => {
+      this.resetWith(this.getInputType(), this.state.sszTypeName);
+    });
+  }
+
+  setFork(e: ChangeEvent<HTMLSelectElement>): void {
+    this.setState({forkName: e.target.value as ForkName}, () => {
       this.resetWith(this.getInputType(), this.state.sszTypeName);
     });
   }
@@ -248,6 +256,25 @@ class Input<T> extends React.Component<Props<T>, State> {
                     onChange={this.setPreset.bind(this)}>
                     {
                       Object.keys(presets).map(
+                        (name) => <option key={name} value={name}>{name}</option>)
+                    }
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div className='field has-addons'>
+              <div className='control'>
+                <a className='button is-static'>
+                  Fork
+                </a>
+              </div>
+              <div className='control'>
+                <div className='select'>
+                  <select
+                    value={this.state.presetName}
+                    onChange={this.setFork.bind(this)}>
+                    {
+                      Object.keys(forks).map(
                         (name) => <option key={name} value={name}>{name}</option>)
                     }
                   </select>

--- a/src/components/Serialize.tsx
+++ b/src/components/Serialize.tsx
@@ -2,17 +2,16 @@ import * as React from "react";
 import {Type} from "@chainsafe/ssz";
 import Output from "./Output";
 import Input from "./Input";
-import {PresetName} from "../util/types";
 import LoadingOverlay from "react-loading-overlay";
 import BounceLoader from "react-spinners/BounceLoader";
 import worker from "workerize-loader!./worker"; // eslint-disable-line import/no-unresolved
+import {ForkName} from "../util/types";
 
 type Props = {
   serializeModeOn: boolean;
 };
 
 type State<T> = {
-  presetName: PresetName | undefined;
   name: string;
   input: T;
   sszType: Type<T> | undefined;
@@ -31,7 +30,7 @@ export default class Serialize<T> extends React.Component<Props, State<T>> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      presetName: undefined,
+      forkName: undefined,
       name: "",
       input: undefined,
       deserialized: undefined,
@@ -51,11 +50,15 @@ export default class Serialize<T> extends React.Component<Props, State<T>> {
     });
   }
 
-  process<T>(presetName: PresetName, name: string, input: T, type: Type<T>): void {
+  process<T>(
+    forkName: ForkName,
+    name: string, input: T, type: Type<T>): void {
 
     let error;
     this.setOverlay(true, this.props.serializeModeOn ? "Serializing..." : "Deserializing...");
-    workerInstance.serialize({sszTypeName: name, presetName: presetName, input})
+    workerInstance.serialize({sszTypeName: name, 
+      forkName,
+      input})
       .then((result: { root: Uint8Array | undefined; serialized: Uint8Array | undefined }) => {
         this.setState({
           hashTreeRoot: result.root,
@@ -70,7 +73,7 @@ export default class Serialize<T> extends React.Component<Props, State<T>> {
 
     const deserialized = input;
 
-    this.setState({presetName, name, input, sszType: type, error, deserialized});
+    this.setState({forkName, name, input, sszType: type, error, deserialized});
   }
 
   render(): JSX.Element {

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -5,10 +5,7 @@ import * as React from "react";
 import EyzyTree from "eyzy-tree";
 import {Node as SSZNode, getChildNodes, getRootNode, isBottomType} from "../util/partials";
 import {
-  BitVectorType,
-  ByteVectorType,
   Type,
-  UintType,
   isBooleanType,
   isUintType,
   isBitListType,
@@ -17,15 +14,9 @@ import {
   isVectorType,
   isListType,
   isContainerType,
-  VectorType,
-  ListType,
 } from "@chainsafe/ssz";
 import BN from "bn.js";
-import {presets, PresetName} from "../util/types";
-
-// const getTypeName = (typ: FullSSZType, types: Record<string, AnySSZType>): string => typeNames[typ.type](typ, types);
-
-// type TypeNameRecords = Record<Type, (t: FullSSZType, types: Record<string, AnySSZType>) => string>
+import { ForkName, forks } from "../util/types";
 
 function getTypeName<T>(type: Type<T>, types: Record<string, Type<T>>, name: string): string | undefined {
   if(isBooleanType(type)) return "bool";
@@ -34,8 +25,8 @@ function getTypeName<T>(type: Type<T>, types: Record<string, Type<T>>, name: str
   else if(isBitVectorType(type)) return `BitVector[${type.length}]`;
   else if(isBitListType(type)) return "Bytes";
   else if(isByteVectorType(type)) return `BytesN[${type.length}]`;
-  else if(isVectorType(type)) return "Vector"; //[${getTypeName(type.elementType, types, 'rescursive placeholder')}, ${(type as VectorType).length}]`;
-  else if(isListType(type)) return "List"; //[${getTypeName(type.elementType, types, 'rescursive placeholder')}]`;
+  else if(isVectorType(type)) return "Vector";
+  else if(isListType(type)) return "List";
   else if(isContainerType(type)) return `${name}(Container)`;
   else return "N/A";
 }
@@ -68,10 +59,10 @@ type NodeProps<T> = {
 };
 
 type Props<T> = {
-  presetName: PresetName;
+  forkName: ForkName;
   input: any;
   sszTypeName: string;
-  sszType: Type<T>; // @TODO: is this correct?
+  sszType: Type<T>;
   name: string | undefined;
 };
 
@@ -168,8 +159,10 @@ export default class TreeView<T> extends React.Component<Props<T>, State<T>> {
   }
 
   render() {
-    const {presetName, sszTypeName} = this.props;
-    const types = presets[presetName];
+    const {
+      forkName, 
+      sszTypeName} = this.props;
+    const types = forks[forkName];
     const {rootNode, selectedNode} = this.state;
     return (
       <div className='container'>

--- a/src/components/worker.tsx
+++ b/src/components/worker.tsx
@@ -1,4 +1,5 @@
-import {presets} from "../util/types";
+// import {presets} from "../util/types";
+import {forks} from "../util/types";
 import {
   BasicType,
   CompositeType,
@@ -34,7 +35,7 @@ function randomBooleanArray(length: number): Array<boolean> {
   return Array.from({length}, () => randomBoolean());
 }
 
-function randomByteVector(length): Uint8Array {
+function randomByteVector(length: number): Uint8Array {
   const array = new Uint8Array(length);
   self.crypto.getRandomValues(array);
   return array;
@@ -77,19 +78,19 @@ boolean | number | bigint | Uint8Array | Array<boolean> | object | undefined {
   }
 }
 
-function getSSZType(data: {sszTypeName: string; presetName: string; input: object}): 
+function getSSZType(data: {sszTypeName: string; forkName: string; input: object}): 
 BasicType<unknown> | CompositeType<object> {
-  return presets[data.presetName][data.sszTypeName];
+  return forks[data.forkName][data.sszTypeName];
 }
 
-export function createRandomValueWorker(data: {sszTypeName: string; presetName: string; input: object}): 
+export function createRandomValueWorker(data: {sszTypeName: string; forkName: string; input: object}): 
 boolean | number | bigint | Uint8Array | Array<boolean> | object | undefined {
   const sszType = getSSZType(data);
   const value = createRandomValue(sszType);
   return value;
 }
 
-export function serialize<T>(data: {sszTypeName: string; presetName: string; input: object}): object {
+export function serialize<T>(data: {sszTypeName: string; forkName: string; input: object}): object {
   const type = getSSZType(data);
   const serialized = type.serialize(data.input);
   const root = type.hashTreeRoot(data.input);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,4 @@
  * @module types 
  */
 
-export * from "@chainsafe/lodestar-types/lib/ssz/presets/mainnet"
+export * from "@chainsafe/lodestar-types"

--- a/src/util/partials.ts
+++ b/src/util/partials.ts
@@ -1,5 +1,4 @@
 import {ListType, Type, isBooleanType, isUintType, isBitListType, isBitVectorType, isContainerType, isVectorType, isByteVectorType, isListType} from "@chainsafe/ssz";
-import BN from "bn.js";
 
 // binary string
 type GenIndex = string

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,7 +1,7 @@
-import deepEqual from "deep-equal";
 import {Type} from "@chainsafe/ssz";
-import {types as mainnetTypes} from "@chainsafe/lodestar-types/lib/ssz/presets/mainnet";
-import {types as minimalTypes} from "@chainsafe/lodestar-types/lib/ssz/presets/minimal";
+import * as mainnetTypes from "@chainsafe/lodestar-config/lib/chainConfig/presets/mainnet";
+import * as minimalTypes from "@chainsafe/lodestar-config/lib/chainConfig/presets/minimal";
+import {allForks, phase0, altair} from "@chainsafe/lodestar-types";
 
 export const presets = {
   mainnet: mainnetTypes as unknown as Record<string, Type<any>>,
@@ -11,5 +11,17 @@ export const presets = {
 export type PresetName = keyof typeof presets;
 
 export function typeNames<T>(types: Record<string, Type<T>>): string[] {
+  return Object.keys(types).sort();
+}
+
+export const forks = {
+  allForks,
+  phase0,
+  altair,
+}
+
+export type ForkName = keyof typeof forks;
+
+export function forkNames<T>(types: Record<string, Type<T>>): string[] {
   return Object.keys(types).sort();
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,11 +1,11 @@
 import {Type} from "@chainsafe/ssz";
-import * as sszTypes from "@chainsafe/lodestar-types/lib/sszTypes";
+import {ssz} from "@chainsafe/lodestar-types";
 
-const {phase0, altair, allForks, ...primitive} = sszTypes;
+const {phase0, altair, allForks, ...primitive} = ssz;
 
 export const forks = {
   phase0: {...phase0, ...primitive} as Record<string, Type<unknown>>,
-  altair: {...altair, ...primitive} as Record<string, Type<unknown>>,
+  altair: {...phase0, ...altair, ...primitive} as Record<string, Type<unknown>>,
 }
 
 export type ForkName = keyof typeof forks;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,27 +1,28 @@
 import {Type} from "@chainsafe/ssz";
 import * as mainnetTypes from "@chainsafe/lodestar-config/lib/chainConfig/presets/mainnet";
 import * as minimalTypes from "@chainsafe/lodestar-config/lib/chainConfig/presets/minimal";
-import {allForks, phase0, altair} from "@chainsafe/lodestar-types";
+import { allForks, phase0, altair } from "@chainsafe/lodestar-types/lib/sszTypes";
+// import {allForks, phase0, altair} from "@chainsafe/lodestar-types";
 
-export const presets = {
-  mainnet: mainnetTypes as unknown as Record<string, Type<any>>,
-  minimal: minimalTypes as unknown as Record<string, Type<any>>,
-} as const;
+// export const presets = {
+//   mainnet: mainnetTypes as unknown as Record<string, Type<any>>,
+//   minimal: minimalTypes as unknown as Record<string, Type<any>>,
+// } as const;
 
-export type PresetName = keyof typeof presets;
+// export type PresetName = keyof typeof presets;
 
-export function typeNames<T>(types: Record<string, Type<T>>): string[] {
-  return Object.keys(types).sort();
-}
+// export function typeNames<T>(types: Record<string, Type<T>>): string[] {
+//   return Object.keys(types).sort();
+// }
 
 export const forks = {
-  allForks,
-  phase0,
-  altair,
+  // allForks: allForks as unknown as Record<string, Type<any>>,
+  phase0: phase0 as Record<string, Type<any>>,
+  altair: altair as Record<string, Type<any>>,
 }
 
 export type ForkName = keyof typeof forks;
 
-export function forkNames<T>(types: Record<string, Type<T>>): string[] {
+export function typeNames<T>(types: Record<string, Type<T>>): string[] {
   return Object.keys(types).sort();
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,24 +1,11 @@
 import {Type} from "@chainsafe/ssz";
-import * as mainnetTypes from "@chainsafe/lodestar-config/lib/chainConfig/presets/mainnet";
-import * as minimalTypes from "@chainsafe/lodestar-config/lib/chainConfig/presets/minimal";
-import { allForks, phase0, altair } from "@chainsafe/lodestar-types/lib/sszTypes";
-// import {allForks, phase0, altair} from "@chainsafe/lodestar-types";
+import * as sszTypes from "@chainsafe/lodestar-types/lib/sszTypes";
 
-// export const presets = {
-//   mainnet: mainnetTypes as unknown as Record<string, Type<any>>,
-//   minimal: minimalTypes as unknown as Record<string, Type<any>>,
-// } as const;
-
-// export type PresetName = keyof typeof presets;
-
-// export function typeNames<T>(types: Record<string, Type<T>>): string[] {
-//   return Object.keys(types).sort();
-// }
+const {phase0, altair, allForks, ...primitive} = sszTypes;
 
 export const forks = {
-  // allForks: allForks as unknown as Record<string, Type<any>>,
-  phase0: phase0 as Record<string, Type<any>>,
-  altair: altair as Record<string, Type<any>>,
+  phase0: {...phase0, ...primitive} as Record<string, Type<unknown>>,
+  altair: {...altair, ...primitive} as Record<string, Type<unknown>>,
 }
 
 export type ForkName = keyof typeof forks;

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,51 +913,53 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@chainsafe/as-sha256@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.2.0.tgz#3ebe061d59d30af9e95a8c22ff4813cbf0e89dbc"
-  integrity sha512-reKklZhY4jSj7JdxdAjUfsaiMt2pdm8V/IqlOR5c4m6Y4tRCxt4f0HBMfyiE2ZQF4tqPPqRVf/ulXwK+LjLIxw==
+"@chainsafe/as-sha256@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.2.2.tgz#f76fae7034c463295bdfb722caf2d93c6fb70d8f"
+  integrity sha512-4WGW1e1/+sFFdFozjuYIrrb7nw0kZHFNWs9k5YNhy8N9p0QfH6FUXlPyoHcrRJfROZ6Gy7MnmOoyPyMZfzw/+Q==
   dependencies:
     "@assemblyscript/loader" "^0.9.2"
     buffer "^5.4.3"
 
-"@chainsafe/lodestar-config@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-config/-/lodestar-config-0.9.0.tgz#d7adeebbc24d39fafc07bec9b0bfc4ddc5f7d078"
-  integrity sha512-0hHhPVenA2tQLCZbsfw3PajZgDenzTmXSTVxZ/spSBp2FsRsARxqIkSWOYyQi+I6TlK/ogVOLQkiWsnEiaZbJQ==
+"@chainsafe/lodestar-config@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-config/-/lodestar-config-0.25.1.tgz#01fdc0816a1e900cf1edbe6951f6d642dd0b8813"
+  integrity sha512-8S/C9OUjKqZB7JQ7Metk2VAtHJmmwNs8t3P9BVeSNodU5Gk6PF/YL6EXGppMolC5Nvj/9NbGPdyBbJWroxC6Xg==
   dependencies:
-    "@chainsafe/lodestar-params" "^0.9.0"
-    "@chainsafe/lodestar-types" "^0.9.0"
+    "@chainsafe/lodestar-params" "^0.25.0"
+    "@chainsafe/lodestar-types" "^0.25.0"
+    "@chainsafe/ssz" "^0.8.11"
 
-"@chainsafe/lodestar-params@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-params/-/lodestar-params-0.9.0.tgz#faed708bd2f81691d965341314cf35ce1a7032dd"
-  integrity sha512-CvECm6YEdD7NfDXEW9Od4rmI4CcC9dLWIxt9hCiqxdra5m/dJcdfWA6rL5wYSzc2rF9qTHpwtzYmrmRKJP/v0A==
+"@chainsafe/lodestar-params@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-params/-/lodestar-params-0.25.0.tgz#385c589172981c1c0e6df672261eefcc70d98e3c"
+  integrity sha512-s3D+LTr76V568qxUsM2bDOU2N9ou9ztuJDqCajLey8bYXSnNpc3l1pvN6D7iIIUDev+c4nsnNcVRWQZgRijsOw==
   dependencies:
+    "@chainsafe/ssz" "^0.8.11"
     js-yaml "^3.13.1"
 
-"@chainsafe/lodestar-types@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-types/-/lodestar-types-0.9.0.tgz#5f2d3e3b480c970aa8a4df5eaa346246db70c1e9"
-  integrity sha512-MJQ0D7ljQ7Cv8COs8c9bAh6JZUVjBD4k3+AtNXxe1p/4JAGLf+CGr1zEB2opYNY0aW3F4wrWI416ZIfwh75gLw==
+"@chainsafe/lodestar-types@^0.25.0", "@chainsafe/lodestar-types@^0.25.1":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-types/-/lodestar-types-0.25.0.tgz#6f3def006a22102aa48c7c2229d5b3081c62e20f"
+  integrity sha512-i3FVBmP3GIHHN5mGdQXGonpBNhwt6GtSTeXE/EllP9rUjT9UVKsdQp7pxg2Llwg8cG2mimi1H4EtLl3ut+Z7Hg==
   dependencies:
-    "@chainsafe/lodestar-params" "^0.9.0"
-    "@chainsafe/ssz" "^0.6.5"
+    "@chainsafe/lodestar-params" "^0.25.0"
+    "@chainsafe/ssz" "^0.8.11"
 
-"@chainsafe/persistent-merkle-tree@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.1.3.tgz#95d16f5faefc4d75f2861859ec5474f34767a4f7"
-  integrity sha512-ZFu7Zoxjt1A9W5whMVlwWJ+dGMF6+iL99lI9g7kIaG1JbI37M0F4TszO5Fe758e6/XJdGl5SFLi+923JYVB/ow==
+"@chainsafe/persistent-merkle-tree@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.3.tgz#00dab8c2af8fe2943b23bc4ba133a96444d40eb7"
+  integrity sha512-3h6UyHQoT4w9lqQioGiGHs2u+RHxFfX0kjfm8hRZhjFQ7/nG7Cd2dsM9FjAfzop8lzQmH2Z1sXjEPLK45oIqrQ==
   dependencies:
-    "@chainsafe/as-sha256" "^0.2.0"
+    "@chainsafe/as-sha256" "^0.2.2"
 
-"@chainsafe/ssz@^0.6.5", "@chainsafe/ssz@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.7.tgz#472683c2d553fbfdb950b7805596f85c0bf46991"
-  integrity sha512-1r6yGc0fa7GMik7xEYKpYm7bTLgSeaLnbER9maS/9PLrpWz794njrwvrREpcUu/yks7SWuKSNJX1b+cAE6x0bA==
+"@chainsafe/ssz@^0.8.11":
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.8.11.tgz#adbddcc7ace83a3c43f0d46d7401fa8cc7430f8e"
+  integrity sha512-d1P3i9Wook/wBMJlTCOJ0bfzaiQiW7JZfBT06IJPI36KgcYSxRiNuNwH6QiJBS3HESvcb86nQNZSHex2OB8stw==
   dependencies:
-    "@chainsafe/as-sha256" "^0.2.0"
-    "@chainsafe/persistent-merkle-tree" "^0.1.3"
+    "@chainsafe/as-sha256" "^0.2.2"
+    "@chainsafe/persistent-merkle-tree" "^0.3.3"
     case "^1.6.3"
 
 "@emotion/cache@^10.0.27":

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,7 +921,7 @@
     "@assemblyscript/loader" "^0.9.2"
     buffer "^5.4.3"
 
-"@chainsafe/lodestar-config@^0.25.1":
+"@chainsafe/lodestar-config@^0.25.0":
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-config/-/lodestar-config-0.25.1.tgz#01fdc0816a1e900cf1edbe6951f6d642dd0b8813"
   integrity sha512-8S/C9OUjKqZB7JQ7Metk2VAtHJmmwNs8t3P9BVeSNodU5Gk6PF/YL6EXGppMolC5Nvj/9NbGPdyBbJWroxC6Xg==
@@ -938,7 +938,7 @@
     "@chainsafe/ssz" "^0.8.11"
     js-yaml "^3.13.1"
 
-"@chainsafe/lodestar-types@^0.25.0", "@chainsafe/lodestar-types@^0.25.1":
+"@chainsafe/lodestar-types@^0.25.0":
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-types/-/lodestar-types-0.25.0.tgz#6f3def006a22102aa48c7c2229d5b3081c62e20f"
   integrity sha512-i3FVBmP3GIHHN5mGdQXGonpBNhwt6GtSTeXE/EllP9rUjT9UVKsdQp7pxg2Llwg8cG2mimi1H4EtLl3ut+Z7Hg==


### PR DESCRIPTION
Updates the @chainsafe packages used, and then uses the phase0 and altair fork types (instead of the mainnet/minimal presets) as dropdown options to select types.

Closes #37 