### PR TITLE
feat: custom container definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@chainsafe/ssz": "^1.2.1",
+				"@lodestar/params": "^1.34.0",
 				"@lodestar/types": "^1.34.0",
 				"comlink": "^4.4.2",
 				"js-yaml": "^4.1.0",
@@ -62,7 +63,6 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -321,7 +321,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
-			"peer": true,
 			"bin": {
 				"biome": "bin/biome"
 			},
@@ -1928,7 +1927,6 @@
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -2024,7 +2022,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2683,7 +2680,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2725,7 +2721,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2735,7 +2730,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -2923,7 +2917,6 @@
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	},
 	"dependencies": {
 		"@chainsafe/ssz": "^1.2.1",
+		"@lodestar/params": "^1.34.0",
 		"@lodestar/types": "^1.34.0",
 		"comlink": "^4.4.2",
 		"js-yaml": "^4.1.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,15 +1,18 @@
 import type {Type} from "@chainsafe/ssz";
-import {useCallback, useEffect, useState} from "react";
+import {useCallback, useEffect, useMemo, useState} from "react";
+import {CustomTypeEditor} from "./components/custom-type-editor";
 import {Footer} from "./components/footer";
 import {Header} from "./components/header";
 import {InputPanel} from "./components/input-panel";
 import {OutputPanel} from "./components/output-panel";
 import {StructureView} from "./components/structure-view/structure-view";
 import {Toolbar} from "./components/toolbar";
+import {useDebounce} from "./hooks/use-debounce";
 import {useSsz} from "./hooks/use-ssz";
 import {useWorker} from "./hooks/use-worker";
+import {type CompileResult, compileCustomDsl} from "./lib/custom-type";
 import {inputFormats, serializeOutputFormats} from "./lib/formats";
-import {type ForkName, forks, typeNames} from "./lib/types";
+import {CUSTOM_FORK, type ForkName, forks, typeNames} from "./lib/types";
 
 const DEFAULT_FORK = "fulu";
 const DEFAULT_TYPE = "BeaconBlock";
@@ -25,6 +28,11 @@ export default function App() {
   const [parsedValue, setParsedValue] = useState<unknown>(null);
   const [inputMode, setInputMode] = useState<"editor" | "builder">("builder");
 
+  // Custom-type DSL state
+  const [customDsl, setCustomDsl] = useState("");
+  const [customCompile, setCustomCompile] = useState<CompileResult | null>(null);
+  const debouncedDsl = useDebounce(customDsl, 300);
+
   // Worker
   const worker = useWorker();
 
@@ -32,7 +40,41 @@ export default function App() {
   const result = useSsz(worker, serializeMode ? "serialize" : "deserialize", forkName, typeName, input, inputFormat);
 
   // Get current SSZ type
-  const sszType: Type<unknown> | null = forks[forkName]?.[typeName] ?? null;
+  const sszType: Type<unknown> | null = useMemo(() => {
+    if (forkName === CUSTOM_FORK) {
+      return customCompile?.ok ? (customCompile.types.get(typeName) ?? null) : null;
+    }
+    return forks[forkName]?.[typeName] ?? null;
+  }, [forkName, typeName, customCompile]);
+
+  // TYPE dropdown options
+  const typeOptions = useMemo(() => {
+    if (forkName === CUSTOM_FORK) {
+      return customCompile?.ok ? customCompile.order : [];
+    }
+    return typeNames(forks[forkName] ?? {});
+  }, [forkName, customCompile]);
+
+  // Compile custom DSL (main thread for UI, worker for serialize/deserialize)
+  useEffect(() => {
+    if (forkName !== CUSTOM_FORK) return;
+    if (!debouncedDsl.trim()) {
+      setCustomCompile(null);
+      return;
+    }
+    const local = compileCustomDsl(debouncedDsl);
+    setCustomCompile(local);
+    if (worker) worker.compileCustom(debouncedDsl);
+  }, [debouncedDsl, forkName, worker]);
+
+  // Keep typeName valid after custom compile changes
+  useEffect(() => {
+    if (forkName !== CUSTOM_FORK) return;
+    if (!customCompile?.ok) return;
+    if (!customCompile.types.has(typeName)) {
+      setTypeName(customCompile.order.at(-1) ?? "");
+    }
+  }, [forkName, customCompile, typeName]);
 
   // Generate default value — callable from button and auto-trigger
   const generateDefault = useCallback(async () => {
@@ -109,12 +151,19 @@ export default function App() {
   const handleForkChange = useCallback(
     (newFork: ForkName) => {
       setForkName(newFork);
+      if (newFork === CUSTOM_FORK) {
+        const order = customCompile?.ok ? customCompile.order : [];
+        if (!order.includes(typeName)) {
+          setTypeName(order.at(-1) ?? "");
+        }
+        return;
+      }
       const types = typeNames(forks[newFork]);
       if (!types.includes(typeName)) {
         setTypeName(DEFAULT_TYPE);
       }
     },
-    [typeName]
+    [typeName, customCompile]
   );
 
   // Handle builder value change — sync to text input
@@ -185,11 +234,21 @@ export default function App() {
       <Toolbar
         forkName={forkName}
         typeName={typeName}
+        typeOptions={typeOptions}
         serializeMode={serializeMode}
         onForkChange={handleForkChange}
         onTypeChange={setTypeName}
         onModeChange={handleModeChange}
       />
+
+      {forkName === CUSTOM_FORK && (
+        <CustomTypeEditor
+          dsl={customDsl}
+          onDslChange={setCustomDsl}
+          error={customCompile && !customCompile.ok ? customCompile.error : null}
+          parsedNames={customCompile?.ok ? customCompile.order : []}
+        />
+      )}
 
       <main className="flex-1 grid grid-cols-1 lg:grid-cols-2 gap-2.5 p-2.5 max-w-[1800px] mx-auto w-full">
         {/* Left: Input */}

--- a/src/components/custom-type-editor.tsx
+++ b/src/components/custom-type-editor.tsx
@@ -1,0 +1,40 @@
+type CustomTypeEditorProps = {
+  dsl: string;
+  onDslChange: (dsl: string) => void;
+  error: string | null;
+  parsedNames: string[];
+};
+
+const PLACEHOLDER = `class MyContainer(Container):
+    slot: uint64
+    parent_root: Bytes32
+    attestations: List[Attestation, 128]`;
+
+export function CustomTypeEditor({dsl, onDslChange, error, parsedNames}: CustomTypeEditorProps) {
+  return (
+    <div className="border-b border-[var(--color-border)] bg-[var(--color-surface-raised)]/40 px-5 py-3">
+      <div className="max-w-[1800px] mx-auto flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] font-medium text-[var(--color-text-muted)] uppercase tracking-widest">
+            Custom Container Definition
+          </span>
+          <span className="text-[10px] font-mono text-[var(--color-text-muted)]">
+            {error ? "parse error" : parsedNames.length > 0 ? `parsed: ${parsedNames.join(", ")}` : "empty"}
+          </span>
+        </div>
+        <textarea
+          className="w-full min-h-[140px] bg-[var(--color-surface)] text-[var(--color-text-primary)] font-mono text-[12px] leading-relaxed rounded-lg border border-[var(--color-border)] p-3 resize-y focus:border-[var(--color-border-focus)] focus:outline-none placeholder:text-[var(--color-text-muted)]/50 transition-colors"
+          value={dsl}
+          onChange={(e) => onDslChange(e.target.value)}
+          placeholder={PLACEHOLDER}
+          spellCheck={false}
+        />
+        {error && (
+          <div className="text-[11px] font-mono text-red-400 bg-red-500/10 border border-red-500/30 rounded px-2 py-1">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -1,16 +1,25 @@
-import {type ForkName, forkNames, forks, typeNames} from "../lib/types";
+import {type ForkName, forkNames} from "../lib/types";
 
 type ToolbarProps = {
   forkName: string;
   typeName: string;
+  typeOptions: string[];
   serializeMode: boolean;
   onForkChange: (fork: ForkName) => void;
   onTypeChange: (type: string) => void;
   onModeChange: (serialize: boolean) => void;
 };
 
-export function Toolbar({forkName, typeName, serializeMode, onForkChange, onTypeChange, onModeChange}: ToolbarProps) {
-  const types = typeNames(forks[forkName]);
+export function Toolbar({
+  forkName,
+  typeName,
+  typeOptions,
+  serializeMode,
+  onForkChange,
+  onTypeChange,
+  onModeChange,
+}: ToolbarProps) {
+  const types = typeOptions;
 
   return (
     <div className="border-b border-[var(--color-border)] bg-[var(--color-surface-raised)]/40 px-5 py-2.5">
@@ -68,13 +77,18 @@ export function Toolbar({forkName, typeName, serializeMode, onForkChange, onType
           <select
             value={typeName}
             onChange={(e) => onTypeChange(e.target.value)}
-            className="bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] text-[12px] font-mono rounded-md px-2.5 py-1 border border-[var(--color-border)] focus:border-[var(--color-border-focus)] focus:outline-none cursor-pointer max-w-[280px]"
+            disabled={types.length === 0}
+            className="bg-[var(--color-surface-overlay)] text-[var(--color-text-primary)] text-[12px] font-mono rounded-md px-2.5 py-1 border border-[var(--color-border)] focus:border-[var(--color-border-focus)] focus:outline-none cursor-pointer max-w-[280px] disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {types.map((name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
+            {types.length === 0 ? (
+              <option value="">—</option>
+            ) : (
+              types.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))
+            )}
           </select>
         </div>
       </div>

--- a/src/lib/custom-type.ts
+++ b/src/lib/custom-type.ts
@@ -1,0 +1,246 @@
+import {
+  type BasicType,
+  BitListType,
+  BitVectorType,
+  BooleanType,
+  ByteListType,
+  ByteVectorType,
+  type CompositeTypeAny,
+  ContainerType,
+  ListBasicType,
+  ListCompositeType,
+  type Type,
+  UintBigintType,
+  UintNumberType,
+  VectorBasicType,
+  VectorCompositeType,
+  isBasicType,
+} from "@chainsafe/ssz";
+import * as params from "@lodestar/params";
+import {forks} from "./types";
+
+const RESOLVE_FORK = "fulu";
+
+const PRIMITIVES: Record<string, () => Type<unknown>> = {
+  uint8: () => new UintNumberType(1),
+  uint16: () => new UintNumberType(2),
+  uint32: () => new UintNumberType(4),
+  uint64: () => new UintBigintType(8),
+  uint128: () => new UintBigintType(16),
+  uint256: () => new UintBigintType(32),
+  boolean: () => new BooleanType(),
+};
+
+type GenArg = {kind: "num"; value: bigint} | {kind: "expr"; expr: TypeExpr};
+type TypeExpr = {kind: "ident"; name: string} | {kind: "generic"; head: string; args: GenArg[]};
+type ParsedField = {name: string; type: TypeExpr; line: number};
+type ParsedClass = {name: string; fields: ParsedField[]; line: number};
+
+export type CompileResult = {ok: true; types: Map<string, Type<unknown>>; order: string[]} | {ok: false; error: string};
+
+export function compileCustomDsl(dsl: string): CompileResult {
+  try {
+    const classes = parseDsl(dsl);
+    if (classes.length === 0) return {ok: false, error: "no classes defined"};
+
+    const customs = new Map<string, Type<unknown>>();
+    const order: string[] = [];
+    const seen = new Set<string>();
+
+    for (const c of classes) {
+      if (seen.has(c.name)) {
+        throw new Error(`line ${c.line}: duplicate class '${c.name}'`);
+      }
+      seen.add(c.name);
+
+      const fields: Record<string, Type<unknown>> = {};
+      for (const f of c.fields) {
+        try {
+          fields[f.name] = buildExpr(f.type, customs);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          throw new Error(`line ${f.line}: ${msg}`);
+        }
+      }
+      customs.set(c.name, new ContainerType(fields, {typeName: c.name}));
+      order.push(c.name);
+    }
+
+    return {ok: true, types: customs, order};
+  } catch (e) {
+    return {ok: false, error: e instanceof Error ? e.message : String(e)};
+  }
+}
+
+function parseDsl(dsl: string): ParsedClass[] {
+  const lines = dsl.split("\n");
+  const classes: ParsedClass[] = [];
+  let current: ParsedClass | null = null;
+
+  const classRe = /^class\s+([A-Za-z_]\w*)\s*\(\s*Container\s*\)\s*:\s*$/;
+  const fieldRe = /^\s+([A-Za-z_]\w*)\s*:\s*(.+?)\s*$/;
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    const cmt = line.indexOf("#");
+    if (cmt >= 0) line = line.slice(0, cmt);
+    if (!line.trim()) continue;
+
+    const mClass = classRe.exec(line);
+    if (mClass) {
+      if (current) classes.push(current);
+      current = {name: mClass[1], fields: [], line: i + 1};
+      continue;
+    }
+
+    if (!current) throw new Error(`line ${i + 1}: expected 'class Name(Container):' header`);
+
+    const mField = fieldRe.exec(line);
+    if (!mField) throw new Error(`line ${i + 1}: invalid field syntax`);
+    current.fields.push({name: mField[1], type: parseTypeExpr(mField[2]), line: i + 1});
+  }
+  if (current) classes.push(current);
+  return classes;
+}
+
+function parseTypeExpr(src: string): TypeExpr {
+  const p = new ExprParser(src);
+  const expr = p.expr();
+  p.skipWs();
+  if (p.i < p.src.length) throw new Error(`unexpected '${p.src.slice(p.i)}'`);
+  return expr;
+}
+
+class ExprParser {
+  i = 0;
+  src: string;
+  constructor(src: string) {
+    this.src = src;
+  }
+
+  skipWs(): void {
+    while (this.i < this.src.length && /\s/.test(this.src[this.i])) this.i++;
+  }
+
+  expr(): TypeExpr {
+    this.skipWs();
+    const name = this.readIdent();
+    this.skipWs();
+    if (this.src[this.i] !== "[") return {kind: "ident", name};
+    this.i++;
+    const args: GenArg[] = [];
+    while (true) {
+      this.skipWs();
+      args.push(this.readArg());
+      this.skipWs();
+      if (this.src[this.i] === ",") {
+        this.i++;
+        continue;
+      }
+      if (this.src[this.i] === "]") {
+        this.i++;
+        break;
+      }
+      throw new Error(`expected ',' or ']' near '${this.src.slice(this.i, this.i + 16)}'`);
+    }
+    return {kind: "generic", head: name, args};
+  }
+
+  readArg(): GenArg {
+    this.skipWs();
+    if (/\d/.test(this.src[this.i] ?? "")) {
+      return {kind: "num", value: this.readNumber()};
+    }
+    const save = this.i;
+    const id = this.readIdent();
+    this.skipWs();
+    if (this.src[this.i] === "[") {
+      this.i = save;
+      return {kind: "expr", expr: this.expr()};
+    }
+    return {kind: "expr", expr: {kind: "ident", name: id}};
+  }
+
+  readIdent(): string {
+    const m = /^[A-Za-z_]\w*/.exec(this.src.slice(this.i));
+    if (!m) throw new Error(`expected identifier at '${this.src.slice(this.i, this.i + 16)}'`);
+    this.i += m[0].length;
+    return m[0];
+  }
+
+  readNumber(): bigint {
+    const m = /^\d+/.exec(this.src.slice(this.i));
+    if (!m) throw new Error("expected number");
+    this.i += m[0].length;
+    return BigInt(m[0]);
+  }
+}
+
+function buildExpr(expr: TypeExpr, customs: Map<string, Type<unknown>>): Type<unknown> {
+  if (expr.kind === "ident") return resolveIdent(expr.name, customs);
+  const {head, args} = expr;
+  switch (head) {
+    case "List": {
+      if (args.length !== 2) throw new Error("List takes 2 args: [elemType, limit]");
+      const elem = buildExpr(asExpr(args[0]), customs);
+      const limit = Number(asSize(args[1]));
+      return isBasicType(elem)
+        ? new ListBasicType(elem as BasicType<unknown>, limit)
+        : new ListCompositeType(elem as CompositeTypeAny, limit);
+    }
+    case "Vector": {
+      if (args.length !== 2) throw new Error("Vector takes 2 args: [elemType, length]");
+      const elem = buildExpr(asExpr(args[0]), customs);
+      const length = Number(asSize(args[1]));
+      return isBasicType(elem)
+        ? new VectorBasicType(elem as BasicType<unknown>, length)
+        : new VectorCompositeType(elem as CompositeTypeAny, length);
+    }
+    case "Bitlist": {
+      if (args.length !== 1) throw new Error("Bitlist takes 1 arg: [limit]");
+      return new BitListType(Number(asSize(args[0])));
+    }
+    case "Bitvector": {
+      if (args.length !== 1) throw new Error("Bitvector takes 1 arg: [length]");
+      return new BitVectorType(Number(asSize(args[0])));
+    }
+    case "ByteList": {
+      if (args.length !== 1) throw new Error("ByteList takes 1 arg: [limit]");
+      return new ByteListType(Number(asSize(args[0])));
+    }
+    case "ByteVector": {
+      if (args.length !== 1) throw new Error("ByteVector takes 1 arg: [length]");
+      return new ByteVectorType(Number(asSize(args[0])));
+    }
+    default:
+      throw new Error(`unknown generic '${head}'`);
+  }
+}
+
+function asExpr(a: GenArg): TypeExpr {
+  if (a.kind === "expr") return a.expr;
+  throw new Error("expected type expression, got number literal");
+}
+
+function asSize(a: GenArg): bigint {
+  if (a.kind === "num") return a.value;
+  if (a.expr.kind === "ident") return resolveConst(a.expr.name);
+  throw new Error("expected integer literal or constant identifier");
+}
+
+function resolveIdent(name: string, customs: Map<string, Type<unknown>>): Type<unknown> {
+  const c = customs.get(name);
+  if (c) return c;
+  const prim = PRIMITIVES[name];
+  if (prim) return prim();
+  const fork = forks[RESOLVE_FORK];
+  if (fork?.[name]) return fork[name];
+  throw new Error(`unknown type '${name}'`);
+}
+
+function resolveConst(name: string): bigint {
+  const v = (params as Record<string, unknown>)[name];
+  if (typeof v === "number" && Number.isFinite(v) && Number.isInteger(v) && v >= 0) return BigInt(v);
+  if (typeof v === "bigint" && v >= 0n) return v;
+  throw new Error(`unknown constant '${name}'`);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,9 +50,11 @@ export const forks = {
   fulu: {...phase0, ...altair, ...bellatrix, ...capella, ...deneb, ...electra, ...fulu, ...primitive},
 } as unknown as Record<string, Record<string, Type<unknown>>>;
 
-export type ForkName = keyof typeof forks;
+export type ForkName = keyof typeof forks | "custom";
 
-export const forkNames = Object.keys(forks);
+export const CUSTOM_FORK = "custom";
+
+export const forkNames = [...Object.keys(forks), CUSTOM_FORK];
 
 export function typeNames(types: Record<string, Type<unknown>>): string[] {
   return Object.keys(types).sort();

--- a/src/workers/ssz-worker.ts
+++ b/src/workers/ssz-worker.ts
@@ -8,26 +8,34 @@ import * as Comlink from "comlink";
 // Lazy-load SSZ libraries via dynamic import so they resolve
 // AFTER the Buffer polyfill assignment above has executed.
 const libs = (async () => {
-  const [{fromHexString}, {inputFormats}, {forks}] = await Promise.all([
+  const [{fromHexString}, {inputFormats}, {forks}, {compileCustomDsl}] = await Promise.all([
     import("@chainsafe/ssz"),
     import("../lib/formats"),
     import("../lib/types"),
+    import("../lib/custom-type"),
   ]);
-  return {fromHexString, inputFormats, forks};
+  return {fromHexString, inputFormats, forks, compileCustomDsl};
 })();
 
 type Type<T> = import("@chainsafe/ssz").Type<T>;
+
+export const CUSTOM_FORK = "custom";
+
+let customTypes: Map<string, Type<unknown>> = new Map();
 
 function getType(
   types: Record<string, Record<string, Type<unknown>>>,
   typeName: string,
   forkName: string
 ): Type<unknown> {
+  if (forkName === CUSTOM_FORK) {
+    const t = customTypes.get(typeName);
+    if (!t) throw new Error(`custom type '${typeName}' not registered`);
+    return t;
+  }
   return types[forkName][typeName];
 }
 
-// Methods are async — they await the libs promise (resolves once, then cached).
-// Comlink transparently handles async return values.
 const worker = {
   async serialize(typeName: string, forkName: string, input: string, inputFormat: string) {
     const {inputFormats, forks} = await libs;
@@ -58,6 +66,14 @@ const worker = {
     const value = type.defaultValue();
     return {value};
   },
+
+  async compileCustom(dsl: string): Promise<{ok: true; order: string[]} | {ok: false; error: string}> {
+    const {compileCustomDsl} = await libs;
+    const result = compileCustomDsl(dsl);
+    if (!result.ok) return {ok: false, error: result.error};
+    customTypes = result.types;
+    return {ok: true, order: result.order};
+  },
 };
 
 export type SszWorkerApi = {
@@ -69,6 +85,7 @@ export type SszWorkerApi = {
   ): Promise<{serialized: Uint8Array; hashTreeRoot: Uint8Array}>;
   deserialize(typeName: string, forkName: string, data: string, inputFormat: string): Promise<{deserialized: unknown}>;
   defaultValue(typeName: string, forkName: string): Promise<{value: unknown}>;
+  compileCustom(dsl: string): Promise<{ok: true; order: string[]} | {ok: false; error: string}>;
 };
 
 // Expose synchronously — Comlink is statically imported so this runs immediately.


### PR DESCRIPTION
## Summary
- Adds a `custom` option to the FORK dropdown that reveals a Python-DSL textarea for defining ad-hoc SSZ containers (consensus-specs `class Foo(Container):` syntax).
- Enables serialize/deserialize/structure-view for types from unreleased forks (e.g. Gloas) without waiting for them to land in `@lodestar/types`.
- Parser supports multiple class blocks (top-down refs), generics (`List`/`Vector`/`Bitlist`/`Bitvector`/`ByteList`/`ByteVector`) with int-literal or `@lodestar/params` constant sizes, and built-in primitives (`uint8..256`, `boolean`). Field idents not defined locally resolve against `forks.fulu`.
- DSL compiles in both main thread (for the in-memory `Type` instance used by the UI) and the worker (for ssz ops), debounced 300ms.

<img width="1836" height="922" alt="Screenshot 2026-05-26 at 7 31 29 PM" src="https://github.com/user-attachments/assets/28a5d061-15b2-46cc-9994-c995d7e5b537" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)